### PR TITLE
Add functionality to get total reactions for a post and improve routes and controller

### DIFF
--- a/backend/src/infra/api/modules/reactions/routes.ts
+++ b/backend/src/infra/api/modules/reactions/routes.ts
@@ -45,6 +45,8 @@ router.get("/all", verifyJWT, reactionsController.getAll);
 router.get("/:id", verifyJWT, reactionsController.getOne);
 router.post("/", verifyJWT, reactionsController.create);
 router.delete("/:id", verifyJWT, reactionsController.delete);
+router.get("/likes/:postId", verifyJWT, reactionsController.getAllByPostId); 
+router.get("/total/:postId", verifyJWT, reactionsController.getTotalReactionsByPostId); 
 router.post("/toggleLike", verifyJWT, reactionsController.toggleLike);
 
 export default router;

--- a/backend/src/infra/services/sequelize/reactions/sequelizeReactionsRepository.ts
+++ b/backend/src/infra/services/sequelize/reactions/sequelizeReactionsRepository.ts
@@ -121,4 +121,27 @@ export class SequelizeReactionsRepository implements ReactionsRepository {
       }
     }
   }
+
+  // Método adicionado para buscar todas as reações de um post específico
+  async findAllByPostId(postId: number): Promise<Reaction[]> {
+    try {
+      const reactions: ReactionModel[] = await ReactionModel.findAll({
+        where: {
+          post_id: postId
+        }
+      });
+      return reactions.map(reaction => ({
+        id: reaction.id,
+        userId: reaction.user_id,
+        postId: reaction.post_id,
+        createdAt: reaction.created_at,
+      }));
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new QueryError("Error in listing reactions by post ID: " + error.message);
+      } else {
+        throw new QueryError("Unknown error in listing reactions by post ID");
+      }
+    }
+  }
 }

--- a/backend/src/modules/reactions/domain/interfaces/reactionsRepository.ts
+++ b/backend/src/modules/reactions/domain/interfaces/reactionsRepository.ts
@@ -6,4 +6,5 @@ export interface ReactionsRepository {
   findOne(id: number): Promise<Reaction | null>;
   create(reaction: CreateReactionRequest): Promise<void>;
   delete(id: number): Promise<void>;
+  findAllByPostId(postId: number): Promise<Reaction[]>; 
 }

--- a/backend/src/modules/reactions/domain/usecases/getAllReactionsByPostIdUseCase.ts
+++ b/backend/src/modules/reactions/domain/usecases/getAllReactionsByPostIdUseCase.ts
@@ -1,0 +1,10 @@
+import { ReactionsRepository } from "../interfaces/reactionsRepository";
+import { Reaction } from "../entities/reaction";
+
+export class GetAllReactionsByPostIdUseCase {
+  constructor(private reactionsRepository: ReactionsRepository) {}
+
+  async execute(postId: number): Promise<Reaction[]> {
+    return await this.reactionsRepository.findAllByPostId(postId);
+  }
+}

--- a/backend/src/modules/reactions/factory.ts
+++ b/backend/src/modules/reactions/factory.ts
@@ -1,9 +1,9 @@
 import { SequelizeReactionsRepository } from "@src/infra/services/sequelize/reactions/sequelizeReactionsRepository";
-
-import { GetAllReactionsUseCase } from "./domain/usecases/getAllReactionsUseCase";
-import { GetSpecificReactionUseCase } from "./domain/usecases/getSpecificReactionUseCase";
-import { CreateReactionUseCase } from "./domain/usecases/createReactionUseCase";
-import { DeleteReactionUseCase } from "./domain/usecases/deleteReactionUseCase";
+import { GetAllReactionsByPostIdUseCase } from "./domain/usecases/getAllReactionsByPostIdUseCase";
+import { GetAllReactionsUseCase } from "@src/modules/reactions/domain/usecases/getAllReactionsUseCase";
+import { GetSpecificReactionUseCase } from "@src/modules/reactions/domain/usecases/getSpecificReactionUseCase";
+import { CreateReactionUseCase } from "@src/modules/reactions/domain/usecases/createReactionUseCase";
+import { DeleteReactionUseCase } from "@src/modules/reactions/domain/usecases/deleteReactionUseCase";
 
 const reactionsRepository = new SequelizeReactionsRepository();
 
@@ -21,4 +21,8 @@ export const createReactionFactory = () => {
 
 export const deleteReactionFactory = () => {
   return new DeleteReactionUseCase(reactionsRepository);
+};
+
+export const getAllReactionsByPostIdFactory = () => {
+  return new GetAllReactionsByPostIdUseCase(reactionsRepository);
 };


### PR DESCRIPTION
## Changes Overview

This Pull Request includes the following changes:
1. **ReactionsController**:
   - Added `getTotalReactionsByPostId` method to return the total number of reactions for a specific post.
   - Improved the existing methods and added necessary error handling.
   - Documented all methods using Swagger.

2. **Routes**:
   - Added new route `/reactions/total/:postId` to get the total number of reactions for a specific post.
   - Ensured all routes are protected using `verifyJWT` middleware.

## Swagger Documentation
- Added detailed Swagger documentation for the new method `getTotalReactionsByPostId`.

## Testing
- Tested the new functionality using Postman to ensure it returns the correct total number of reactions for a given post.

## Steps to Review
1. Review the changes in `ReactionsController`.
2. Review the changes in `reactionsRoutes.ts`.
3. Ensure the documentation is accurate and clear.
4. Test the new endpoint `/reactions/total/:postId` to confirm it works as expected.

Please review the changes and provide feedback. Thank you!
